### PR TITLE
Fix logger initialize being passed 2 arguments

### DIFF
--- a/lib/entangler/executor/base.rb
+++ b/lib/entangler/executor/base.rb
@@ -53,7 +53,7 @@ module Entangler
       end
 
       def logger
-        @logger ||= Entangler::Logger.new(log_outputs, @opts[:verbose])
+        @logger ||= Entangler::Logger.new(log_outputs, verbose: @opts[:verbose])
       end
 
       def log_outputs


### PR DESCRIPTION
Logger initilalize expects `(outputs, verbose: false)`
However it is getting initialized with `Entangler::Logger.new(log_outputs, @opts[:verbose])`

This PR changes it to `Entangler::Logger.new(log_outputs, verbose: @opts[:verbose])`

This is related to the following issue https://github.com/daveallie/entangler/issues/6