### PR TITLE
Bump `listen` dependency version

### DIFF
--- a/entangler.gemspec
+++ b/entangler.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.6'
   spec.add_development_dependency 'rubocop-rake', '~> 0.5.1'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0'
-  spec.add_dependency 'listen', '~> 3.3'
+  spec.add_dependency 'listen', '~> 3.7'
   spec.add_dependency 'to_regexp', '~> 0.2.1'
 end


### PR DESCRIPTION
The `listen` gem is dependent on `rb-fsevent`. However, the version of `listen` currently used here is from before Apple M1 chip support was added for `rb-fsevent` (see [here](https://github.com/guard/rb-fsevent/pull/88)), resulting in the following error when run on M1 macs:
![image](https://user-images.githubusercontent.com/5846629/149458555-ec529e27-3378-42b2-8d99-a7ead55676d6.png)

Bumping this version should give the entangler M1 support.