### PR TITLE
Better error message if remote is not installed

### DIFF
--- a/lib/entangler/errors.rb
+++ b/lib/entangler/errors.rb
@@ -4,4 +4,5 @@ module Entangler
   class EntanglerError < StandardError; end
   class ValidationError < EntanglerError; end
   class VersionMismatchError < EntanglerError; end
+  class NotInstalledOnRemoteError < EntanglerError; end
 end

--- a/lib/entangler/executor/validation/master.rb
+++ b/lib/entangler/executor/validation/master.rb
@@ -50,12 +50,18 @@ module Entangler
           return unless @opts[:remote_mode]
 
           res = `#{generate_ssh_command('source ~/.rvm/environments/default && entangler --version')}`
+          if res.empty?
+            msg = 'Entangler is not installed on the remote server.' \
+                  ' Install Entangler on the remote server (SSH in, then `gem install entangler`), then try again.'
+            raise Entangler::NotInstalledOnRemoteError, msg
+          end
+
           remote_version = Gem::Version.new(res.strip)
           local_version = Gem::Version.new(Entangler::VERSION)
           return unless major_version_mismatch?(local_version, remote_version)
 
           msg = 'Entangler version too far apart, please update either local or remote Entangler.' \
-              " Local version is #{local_version} and remote version is #{remote_version}."
+                " Local version is #{local_version} and remote version is #{remote_version}."
           raise Entangler::VersionMismatchError, msg
         end
 


### PR DESCRIPTION
Previously you'd get this:

```
Entangler version too far apart, please update either local or remote Entangler. Local version is 1.2.2 and remote version is 0
```

Which is a bit confusing.