### PR TITLE
Remove rvm requirement

### DIFF
--- a/lib/entangler/executor/validation/master.rb
+++ b/lib/entangler/executor/validation/master.rb
@@ -49,7 +49,7 @@ module Entangler
         def validate_remote_entangler_version
           return unless @opts[:remote_mode]
 
-          res = `#{generate_ssh_command('source ~/.rvm/environments/default && entangler --version')}`
+          res = `#{generate_ssh_command('(source ~/.rvm/environments/default || echo) && entangler --version')}`
           if res.empty?
             msg = 'Entangler is not installed on the remote server.' \
                   ' Install Entangler on the remote server (SSH in, then `gem install entangler`), then try again.'


### PR DESCRIPTION
Running `entangler` runs `source ~/.rvm/environments/default`, which fails if rvm is not installed.

Remove this requirement, allowing entangler to run without rvm.