### PR TITLE
Fix buggy bash syntax

### DIFF
--- a/lib/entangler/executor/master.rb
+++ b/lib/entangler/executor/master.rb
@@ -60,7 +60,7 @@ module Entangler
       def generate_ssh_command(cmd, source_rvm: false)
         prefixed_cmd =
           if source_rvm && !@opts[:no_rvm]
-            "([[ -f ~/.rvm/environments/default ]] && source ~/.rvm/environments/default || true) && #{cmd}"
+            "[[ -f ~/.rvm/environments/default ]] && source ~/.rvm/environments/default || true && #{cmd}"
           else
             cmd
           end


### PR DESCRIPTION
bug in https://github.com/daveallie/entangler/pull/11

```
% ssh -q ruby@(ip) -p 22 -C "([[ -f ~/.rvm/environments/default ]] && source ~/.rvm/environments/default || true) && entangler --version"
bash: entangler: command not found

% ssh -q ruby@(ip) -p 22 -C "[[ -f ~/.rvm/environments/default ]] && source ~/.rvm/environments/default || true && entangler --version"
1.3.0
```