### PR TITLE
Prevent File.read on directories

### DIFF
--- a/lib/entangler/entangled_file.rb
+++ b/lib/entangler/entangled_file.rb
@@ -18,6 +18,10 @@ module Entangler
       Entangler.executor.generate_abs_path(@path)
     end
 
+    def not_a_directory?
+      !File.directory?(full_path)
+    end
+
     def file_exists?
       File.exist?(full_path)
     end
@@ -56,7 +60,7 @@ module Entangler
     end
 
     def marshal_dump
-      if file_exists? && (action == :create || action == :update)
+      if file_exists? && not_a_directory? && (action == :create || action == :update)
         @desired_modtime = File.mtime(full_path).to_i
         @contents = File.read(full_path)
       end


### PR DESCRIPTION
- Fixes an issue where we can try to read the binary of a directory which results in a hard crash.

### Example of the error

![image](https://github.com/daveallie/entangler/assets/80095448/c6e5af4c-21a0-4fc7-a93b-ec3d099c0c83)


A simple way to reproduce the problem

```ruby
`mkdir test_dir`
full_path="${Dir.pwd}/test_dir"

File.exist(full_path) # => true
File.read(full_path) #=> Is a directory @ io_fread - /home/ruby/core/repo/test_dir (Errno::EISDIR)
```
