### PR TITLE
Revert "Prevent File.read on directories"

### DIFF
--- a/lib/entangler/entangled_file.rb
+++ b/lib/entangler/entangled_file.rb
@@ -18,10 +18,6 @@ module Entangler
       Entangler.executor.generate_abs_path(@path)
     end
 
-    def not_a_directory?
-      !File.directory?(full_path)
-    end
-
     def file_exists?
       File.exist?(full_path)
     end
@@ -60,7 +56,7 @@ module Entangler
     end
 
     def marshal_dump
-      if file_exists? && not_a_directory? && (action == :create || action == :update)
+      if file_exists? && (action == :create || action == :update)
         @desired_modtime = File.mtime(full_path).to_i
         @contents = File.read(full_path)
       end


### PR DESCRIPTION
Reverts daveallie/entangler#13

Sorry @daveallie I should have commented on the PR.

We are worried this will swallow changes in the directory.

The bug we are trying to fix, is really a bug in `listen`, not `entangler`.