### PR TITLE
Add `--force-polling` option to enable `listen`'s polling adapter

### DIFF
--- a/exe/entangler
+++ b/exe/entangler
@@ -18,12 +18,15 @@ def value_opt(options, opts, key, *args)
 end
 
 options = {}
+# rubocop:disable Metrics/BlockLength
 OptionParser.new do |opts|
-  opts.banner = %(Entangler v#{Entangler::VERSION}
+  opts.banner = <<~BANNER
+    Entangler v#{Entangler::VERSION}
 
-Usage:
-   entangler master <base_dir> <remote_user>@<remote_host>:<remote_base_dir> [options]
-   entangler master <base_dir> <other_synced_base_dir> [options])
+    Usage:
+      entangler master <base_dir> <remote_user>@<remote_host>:<remote_base_dir> [options]
+      entangler master <base_dir> <other_synced_base_dir> [options]
+  BANNER
 
   opts.separator ''
   opts.separator 'Options:'
@@ -36,8 +39,14 @@ Usage:
 
   value_opt(options, opts, :port, '-p', '--port PORT', 'Overwrite the SSH port (usually 22)',
             "(doesn't do anything in slave mode)")
+
+  bool_opt(options, opts, :force_polling, '--force-polling',
+           'Forces the use of the listen polling adapter (works cross-platform, generally slower)')
+
   bool_opt(options, opts, :no_rvm, '--no-rvm', 'Skip attempting to load RVM on remote')
+
   bool_opt(options, opts, :verbose, '-v', '--verbose', 'Log Debug lines')
+
   bool_opt(options, opts, :quiet, '-q', '--quiet', "Don't log to stdout in master process")
 
   opts.on_tail('--version', 'Show version number') do
@@ -50,6 +59,7 @@ Usage:
     exit
   end
 end.parse!
+# rubocop:enable Metrics/BlockLength
 
 mode = ARGV.shift
 unless mode && %w[master slave].include?(mode)
@@ -102,17 +112,18 @@ end
 
 if options[:ignore]
   opts[:ignore] = options[:ignore].map do |opt|
-    opt = opt[1..-2] if opt.start_with?('"') && opt.end_with?('"') || opt.start_with?("'") && opt.end_with?("'")
+    opt = opt[1..-2] if (opt.start_with?('"') && opt.end_with?('"')) || (opt.start_with?("'") && opt.end_with?("'"))
 
     if ToRegexp::String.literal? opt
       source, *rest = opt.as_regexp(detect: true)
-      ::Regexp.new "^#{source}(?:/[^/]+)*$", *rest
+      Regexp.new "^#{source}(?:/[^/]+)*$", *rest
     else
       opt.to_regexp(detect: true)
     end
   end
 end
 
+opts[:force_polling] = options[:force_polling]
 opts[:no_rvm] = options[:no_rvm]
 opts[:quiet] = options[:quiet]
 opts[:verbose] = options[:verbose]

--- a/lib/entangler/executor/background/base.rb
+++ b/lib/entangler/executor/background/base.rb
@@ -42,12 +42,12 @@ module Entangler
         private
 
         def listener
-          @listener ||= begin
-            Listen::Listener.new(base_dir, ignore!: @opts[:ignore]) do |modified, added, removed|
-              process_local_changes(generate_entangled_files(added, :create) +
-                                        generate_entangled_files(modified, :update) +
-                                        generate_entangled_files(removed, :delete))
-            end
+          @listener ||= Listen::Listener.new(base_dir,
+                                             ignore!: @opts[:ignore],
+                                             force_polling: @opts[:force_polling]) do |modified, added, removed|
+            process_local_changes(generate_entangled_files(added, :create) +
+                                  generate_entangled_files(modified, :update) +
+                                  generate_entangled_files(removed, :delete))
           end
         end
 

--- a/lib/entangler/executor/base.rb
+++ b/lib/entangler/executor/base.rb
@@ -11,6 +11,9 @@ module Entangler
       include Entangler::Executor::Background::Base
       include Entangler::Executor::Validation::Base
 
+      GIT_IGNORE_REGEX = %r{^\.git(?:/[^/]+)*$}.freeze
+      ENTANGLER_IGNORE_REGEX = /^\.entangler.*/.freeze
+
       attr_reader :base_dir
 
       def initialize(base_dir, opts = {})
@@ -19,8 +22,9 @@ module Entangler
         @recently_received_paths = []
         @listener_pauses = [false, false]
         @opts = opts
-        @opts[:ignore] = [%r{^\.git(?:/[^/]+)*$}] unless @opts.key?(:ignore)
-        @opts[:ignore] << /^\.entangler.*/
+        @opts[:ignore] = [GIT_IGNORE_REGEX] unless @opts.key?(:ignore)
+        @opts[:ignore] << ENTANGLER_IGNORE_REGEX
+        @opts[:force_polling] ||= false
 
         validate_opts
         Entangler::Logger.create_log_dir(base_dir)
@@ -55,6 +59,8 @@ module Entangler
       def logger
         @logger ||= Entangler::Logger.new(log_outputs, verbose: @opts[:verbose])
       end
+
+      private
 
       def log_outputs
         [Entangler::Logger.log_file_path(base_dir)]

--- a/lib/entangler/version.rb
+++ b/lib/entangler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Entangler
-  VERSION = '1.3.2'
+  VERSION = '1.3.3'
 end

--- a/spec/entangler/executor/master_spec.rb
+++ b/spec/entangler/executor/master_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Entangler::Executor::Master do
-  describe 'validaton' do
+  describe 'validation' do
     it "is invalid if the remote directory doesn't exist" do
       with_temp_dir do |dir|
         expect { described_class.new(dir, remote_base_dir: File.join(dir, 'asdf')) }.to(


### PR DESCRIPTION
Related:
- https://github.com/daveallie/entangler/pull/13
- https://github.com/daveallie/entangler/pull/14

We've identified an issue where docker volumes seem to be omitting an `IN_ISDIR` event when new empty directories are created and detected by [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html) (utilised by `rb-inotify` [in `listen`'s linux adapter](https://github.com/guard/listen/blob/fd85e1cb2375767e3cbc4b5743ff50061e8a6c75/lib/listen/adapter/linux.rb#L5)), essentially causing `inotify` to report new directories as new files. This eventually results in a crash when trying to read the directory as a file [here](https://github.com/daveallie/entangler/blob/4ec49731e778b85f4e5c2d7702aa06c074adff48/lib/entangler/entangled_file.rb#L61).

Our temporary solution has been to force the use of the [polling (generic)](https://github.com/guard/listen/blob/master/lib/listen/adapter/polling.rb) adapter via [this fork](https://github.com/joshuay03/entangler/commit/44af69184a835e4cf11de559e7a266cf538df36b) until we can provide support for this option in `entangler` itself, which this PR does.

`listen` docs for reference: https://github.com/guard/listen

cc @ghiculescu @daveallie