### PR TITLE
Set up log rotation

### DIFF
--- a/lib/entangler/logger.rb
+++ b/lib/entangler/logger.rb
@@ -15,7 +15,7 @@ module Entangler
 
     def initialize(outputs, verbose: false)
       @loggers = Array(outputs).map do |output|
-        logger = ::Logger.new(output, 1, 10485760) # 10.megabytes.to_i
+        logger = ::Logger.new(output, 1, 10_485_760) # 10.megabytes.to_i
 
         logger.level = verbose ? ::Logger::DEBUG : ::Logger::INFO
         logger.formatter = proc do |severity, datetime, _, msg|

--- a/lib/entangler/logger.rb
+++ b/lib/entangler/logger.rb
@@ -15,7 +15,7 @@ module Entangler
 
     def initialize(outputs, verbose: false)
       @loggers = Array(outputs).map do |output|
-        logger = ::Logger.new(output)
+        logger = ::Logger.new(output, 1, 10485760) # 10.megabytes.to_i
 
         logger.level = verbose ? ::Logger::DEBUG : ::Logger::INFO
         logger.formatter = proc do |severity, datetime, _, msg|


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/44888

If my reading of https://github.com/ruby/logger/blob/0996f90650fd95718f0ffe835b965de18654b71c/lib/logger/log_device.rb#L176 is correct, this will:

- Prevent the log file size from exceeding 10mb.
- Keep at most two log files (`entangler.log` and `entangler.log.0`).