### PR TITLE
Add option for custom SSH config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Options:
                                      All paths should be relative to the base sync directory.
     -p, --port PORT                  Overwrite the SSH port (usually 22)
                                      (doesn't do anything in slave mode)
+    -c, --config PATH                Use a custom SSH config (usually $HOME/.ssh/config)
+                                     (doesn't do anything in slave mode)
         --force-polling              Forces the use of the listen polling adapter
                                      (works cross-platform, generally slower, doesn't do anything in slave mode)
         --no-rvm                     Skip attempting to load RVM on remote

--- a/exe/entangler
+++ b/exe/entangler
@@ -40,6 +40,9 @@ OptionParser.new do |opts|
   value_opt(options, opts, :port, '-p', '--port PORT', 'Overwrite the SSH port (usually 22)',
             "(doesn't do anything in slave mode)")
 
+  value_opt(options, opts, :config, '-c', '--config PATH', 'Use a custom SSH config (usually $HOME/.ssh/config)',
+            "(doesn't do anything in slave mode)")
+
   bool_opt(options, opts, :force_polling, '--force-polling',
            'Forces the use of the listen polling adapter',
            "(works cross-platform, generally slower, doesn't do anything in slave mode)")
@@ -124,6 +127,7 @@ if options[:ignore]
   end
 end
 
+opts[:config] = options[:config]
 opts[:force_polling] = options[:force_polling]
 opts[:no_rvm] = options[:no_rvm]
 opts[:quiet] = options[:quiet]

--- a/lib/entangler/executor/master.rb
+++ b/lib/entangler/executor/master.rb
@@ -65,7 +65,9 @@ module Entangler
             cmd
           end
 
-        "ssh -q #{remote_hostname} -p #{@opts[:remote_port]} -C \"#{prefixed_cmd}\""
+        ssh = "ssh -q #{remote_hostname} -p #{@opts[:remote_port]}"
+        ssh += " -F #{@opts[:config]}" if @opts[:config]
+        ssh + " -C \"#{prefixed_cmd}\""
       end
 
       def remote_hostname
@@ -83,7 +85,10 @@ module Entangler
         remote_path += "#{@opts[:remote_base_dir]}/"
 
         cmd = "rsync -azv --exclude-from #{rsync_ignores_file_path}"
-        cmd += " -e \"ssh -p #{@opts[:remote_port]}\"" if @opts[:remote_mode]
+        if @opts[:remote_mode]
+          config = @opts[:config] ? "-F #{@opts[:config]}" : ''
+          cmd += " -e \"ssh -p #{@opts[:remote_port]} #{config}\""
+        end
         cmd + " --delete #{base_dir}/ #{remote_path}"
       end
     end

--- a/lib/entangler/version.rb
+++ b/lib/entangler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Entangler
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
Adds a `-c` or `--config` option to use a custom SSH config on initial `rsync` and on subsequent changes.

~This assumes that you have a default SSH config when not using this option but I think most machines will have one by default.~

Tested locally :)

@ghiculescu